### PR TITLE
Add HTTP Prefix to search form action

### DIFF
--- a/scripts/lua/inc/search_host_box.lua
+++ b/scripts/lua/inc/search_host_box.lua
@@ -3,7 +3,9 @@
 --
 
 print [[
-	 <li><form action="/lua/host_details.lua">
+	 <li><form action="]]
+	 print (ntop.getHttpPrefix())
+	 print [[/lua/host_details.lua">
 ]]
 
 -- FIX: show notifications to the user


### PR DESCRIPTION
When searching for a host in the masthead search field: after selecting a host and pressing "enter" a 404 error is thrown (when using a HTTP prefix in the config file).

This patch fixes this.